### PR TITLE
AsyncActionButton | prevent button from getting stuck in loading state

### DIFF
--- a/lib/core/widgets/button/async_action_button.dart
+++ b/lib/core/widgets/button/async_action_button.dart
@@ -28,24 +28,25 @@ class AsyncActionButton extends StatefulWidget {
 
 class _AsyncActionButtonState extends State<AsyncActionButton> {
   late bool _isInProgress;
+  //
   @override
   void initState() {
     _isInProgress = false;
     super.initState();
   }
   void _onPressed() {
+    final onPressed = widget._onPressed;
+    if (onPressed == null) return;
     setState(() {
       _isInProgress = true;
     });
-    widget._onPressed
-      ?.call()
-      .then((_) {
-        if (mounted) {
-          setState(() {
-            _isInProgress = false;
-          });
-        }
-      });
+    onPressed().whenComplete(() {
+      if (mounted) {
+        setState(() {
+          _isInProgress = false;
+        });
+      }
+    });
   }
   //
   @override


### PR DESCRIPTION
Button could get stuck in loading state if future is completed with error or `widget._onPressed` is null.
To prevent that condition `.then()` was replaced with `.whenComplete()` and null check for `widget._onPressed` was added.